### PR TITLE
Allow a background to be specified for a tooltip

### DIFF
--- a/app/src/main/java/it/sephiroth/android/library/mymodule/app/MainActivity2.java
+++ b/app/src/main/java/it/sephiroth/android/library/mymodule/app/MainActivity2.java
@@ -22,6 +22,7 @@ public class MainActivity2 extends ActionBarActivity implements View.OnClickList
 
 	Button mButton1;
 	Button mButton2;
+	Button mButton3;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -30,8 +31,10 @@ public class MainActivity2 extends ActionBarActivity implements View.OnClickList
 
 		mButton1 = (Button) findViewById(R.id.button1);
 		mButton2 = (Button) findViewById(R.id.button2);
+		mButton3 = (Button) findViewById(R.id.button3);
 		mButton1.setOnClickListener(this);
 		mButton2.setOnClickListener(this);
+		mButton3.setOnClickListener(this);
 	}
 
 
@@ -90,6 +93,18 @@ public class MainActivity2 extends ActionBarActivity implements View.OnClickList
 			       .toggleArrow(true)
 			       .maxWidth(400)
 			       .withCallback(this)
+			       .show();
+		}
+		else if (id == mButton3.getId()) {
+			manager.create(2)
+			       .anchor(mButton3, TooltipManager.Gravity.BOTTOM)
+			       .actionBarSize(Utils.getActionBarSize(getBaseContext()))
+			       .closePolicy(TooltipManager.ClosePolicy.TouchOutside, 0)
+			       .text(R.string.hello_world)
+			       .toggleArrow(true)
+			       .maxWidth(400)
+			       .withCallback(this)
+			       .background(R.color.black_dark_transparent)
 			       .show();
 		}
 	}

--- a/app/src/main/res/layout/activity_main_activity2.xml
+++ b/app/src/main/res/layout/activity_main_activity2.xml
@@ -22,5 +22,14 @@
 		android:layout_below="@+id/button1"
 		android:layout_alignParentLeft="true"
 		android:layout_alignParentStart="true" />
+			
+	<Button
+		android:id="@+id/button3"
+		android:text="@string/hello_world"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:layout_below="@+id/button2"
+		android:layout_alignParentLeft="true"
+		android:layout_alignParentStart="true" />
 
 </RelativeLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,0 +1,3 @@
+<resources>
+	<color name="black_dark_transparent">#88000000</color>
+</resources>

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipManager.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipManager.java
@@ -221,6 +221,7 @@ public class TooltipManager {
 		View view;
 		Gravity gravity;
 		int actionbarSize = 0;
+		int backgroundColorResId = 0;
 		int textResId = R.layout.tooltip_textview;
 		ClosePolicy closePolicy;
 		long showDuration;
@@ -351,6 +352,11 @@ public class TooltipManager {
 
 		public Builder showDelay(long ms) {
 			this.showDelay = ms;
+			return this;
+		}
+		
+		public Builder background(int colorResId) {
+			this.backgroundColorResId = colorResId;
 			return this;
 		}
 

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipView.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipView.java
@@ -91,6 +91,10 @@ class TooltipView extends ViewGroup implements Tooltip {
 		this.fadeDuration = builder.fadeDuration;
 		this.closeCallback = builder.closeCallback;
 
+		if (builder.backgroundColorResId > 0) {
+			setBackgroundColor(context.getResources().getColor(builder.backgroundColorResId));
+		}
+
 		if (null != builder.point) {
 			this.point = new Point(builder.point);
 			this.point.y += topRule;


### PR DESCRIPTION
As mentioned in #2, this allows a tooltip background to be specified so that you can have a dimmed background like so:

![dim](https://cloud.githubusercontent.com/assets/277576/4539646/1cdfab98-4dff-11e4-9887-f3eda3ac64a0.gif)
