### PR TITLE
ClassCastException when casting ContextThemeWrapper to Activity

### DIFF
--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
@@ -9,6 +9,7 @@ import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
+import android.content.ContextWrapper;
 import android.content.res.ColorStateList;
 import android.content.res.Resources;
 import android.content.res.TypedArray;
@@ -284,7 +285,9 @@ public final class Tooltip {
                     return;
                 }
 
-                Activity activity = (Activity) getContext();
+                // in some devices casting ContextThemeWrapper/ContextWrapper to Activity throws
+                // ClassCastException. Scan for the activity instead.
+                Activity activity = scanForActivity(getContext());
                 if (null != activity) {
                     if (activity.isFinishing()) {
                         log(TAG, WARN, "[%d] skipped because activity is finishing...", mToolTipId);
@@ -297,6 +300,19 @@ public final class Tooltip {
                 }
             }
         };
+
+        @Nullable
+        private static Activity scanForActivity(Context cont) {
+            if (cont == null)
+                return null;
+            else if (cont instanceof Activity)
+                return (Activity)cont;
+            else if (cont instanceof ContextWrapper)
+                return scanForActivity(((ContextWrapper)cont).getBaseContext());
+
+            return null;
+        }
+
         private Runnable hideRunnable = new Runnable() {
             @Override
 

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
@@ -67,12 +67,12 @@ public final class Tooltip {
         // empty
     }
 
-    @SuppressWarnings ("unused")
+    @SuppressWarnings("unused")
     public static TooltipView make(Context context, Builder builder) {
         return new TooltipViewImpl(context, builder);
     }
 
-    @SuppressWarnings ("unused")
+    @SuppressWarnings("unused")
     public static boolean remove(Context context, final int tooltipId) {
         final Activity act = Utils.getActivity(context);
         if (act != null) {
@@ -92,7 +92,7 @@ public final class Tooltip {
         return false;
     }
 
-    @SuppressWarnings ("unused")
+    @SuppressWarnings("unused")
     public static boolean removeAll(Context context) {
         final Activity act = Utils.getActivity(context);
         if (act != null) {
@@ -109,7 +109,7 @@ public final class Tooltip {
         return false;
     }
 
-    @SuppressWarnings ("unused")
+    @SuppressWarnings("unused")
     public static class ClosePolicy {
         static final int NONE = 0;
         static final int TOUCH_INSIDE = 1 << 1;
@@ -124,7 +124,7 @@ public final class Tooltip {
         public static final ClosePolicy TOUCH_OUTSIDE_NO_CONSUME = new ClosePolicy(TOUCH_OUTSIDE);
         public static final ClosePolicy TOUCH_ANYWHERE_NO_CONSUME = new ClosePolicy(TOUCH_INSIDE | TOUCH_OUTSIDE);
         public static final ClosePolicy TOUCH_ANYWHERE_CONSUME =
-            new ClosePolicy(TOUCH_INSIDE | TOUCH_OUTSIDE | CONSUME_INSIDE | CONSUME_OUTSIDE);
+                new ClosePolicy(TOUCH_INSIDE | TOUCH_OUTSIDE | CONSUME_INSIDE | CONSUME_OUTSIDE);
 
         public ClosePolicy() {
             policy = NONE;
@@ -181,7 +181,7 @@ public final class Tooltip {
         LEFT, RIGHT, TOP, BOTTOM, CENTER
     }
 
-    @SuppressWarnings ("unused")
+    @SuppressWarnings("unused")
     public interface TooltipView {
         void show();
 
@@ -234,7 +234,7 @@ public final class Tooltip {
         void onTooltipHidden(final TooltipView view);
     }
 
-    @SuppressLint ("ViewConstructor")
+    @SuppressLint("ViewConstructor")
     static class TooltipViewImpl extends ViewGroup implements TooltipView {
         public static final int TOLERANCE_VALUE = 10;
         private static final String TAG = "TooltipView";
@@ -276,7 +276,7 @@ public final class Tooltip {
             }
 
             @Override
-            @TargetApi (17)
+            @TargetApi(17)
             public void onViewDetachedFromWindow(final View v) {
                 log(TAG, INFO, "[%d] onViewDetachedFromWindow", mToolTipId);
                 removeViewListeners(v);
@@ -306,9 +306,9 @@ public final class Tooltip {
             if (cont == null)
                 return null;
             else if (cont instanceof Activity)
-                return (Activity)cont;
+                return (Activity) cont;
             else if (cont instanceof ContextWrapper)
-                return scanForActivity(((ContextWrapper)cont).getBaseContext());
+                return scanForActivity(((ContextWrapper) cont).getBaseContext());
 
             return null;
         }
@@ -375,41 +375,41 @@ public final class Tooltip {
         private AnimationBuilder mFloatingAnimation;
         private boolean mAlreadyCheck;
         private final ViewTreeObserver.OnGlobalLayoutListener mGlobalLayoutListener =
-            new ViewTreeObserver.OnGlobalLayoutListener() {
-                @Override
-                public void onGlobalLayout() {
-                    if (!mAttached) {
-                        removeGlobalLayoutObserver(null);
-                        return;
-                    }
+                new ViewTreeObserver.OnGlobalLayoutListener() {
+                    @Override
+                    public void onGlobalLayout() {
+                        if (!mAttached) {
+                            removeGlobalLayoutObserver(null);
+                            return;
+                        }
 
-                    if (null != mViewAnchor) {
-                        View view = mViewAnchor.get();
+                        if (null != mViewAnchor) {
+                            View view = mViewAnchor.get();
 
-                        if (null != view) {
-                            view.getHitRect(mTempRect);
-                            view.getLocationOnScreen(mTempLocation);
+                            if (null != view) {
+                                view.getHitRect(mTempRect);
+                                view.getLocationOnScreen(mTempLocation);
 
-                            if (dbg) {
-                                log(TAG, INFO, "[%d] onGlobalLayout(dirty: %b)", mToolTipId, view.isDirty());
-                                log(TAG, VERBOSE, "[%d] hitRect: %s, old: %s", mToolTipId, mTempRect, mHitRect);
-                            }
+                                if (dbg) {
+                                    log(TAG, INFO, "[%d] onGlobalLayout(dirty: %b)", mToolTipId, view.isDirty());
+                                    log(TAG, VERBOSE, "[%d] hitRect: %s, old: %s", mToolTipId, mTempRect, mHitRect);
+                                }
 
-                            if (!mTempRect.equals(mHitRect)) {
-                                mHitRect.set(mTempRect);
+                                if (!mTempRect.equals(mHitRect)) {
+                                    mHitRect.set(mTempRect);
 
-                                mTempRect.offsetTo(mTempLocation[0], mTempLocation[1]);
-                                mViewRect.set(mTempRect);
-                                calculatePositions();
-                            }
-                        } else {
-                            if (dbg) {
-                                log(TAG, WARN, "[%d] view is null", mToolTipId);
+                                    mTempRect.offsetTo(mTempLocation[0], mTempLocation[1]);
+                                    mViewRect.set(mTempRect);
+                                    calculatePositions();
+                                }
+                            } else {
+                                if (dbg) {
+                                    log(TAG, WARN, "[%d] view is null", mToolTipId);
+                                }
                             }
                         }
                     }
-                }
-            };
+                };
 
         private boolean mIsCustomView;
 
@@ -417,12 +417,12 @@ public final class Tooltip {
             super(context);
 
             TypedArray theme =
-                context.getTheme()
-                    .obtainStyledAttributes(null, R.styleable.TooltipLayout, builder.defStyleAttr, builder.defStyleRes);
+                    context.getTheme()
+                            .obtainStyledAttributes(null, R.styleable.TooltipLayout, builder.defStyleAttr, builder.defStyleRes);
             this.mPadding = theme.getDimensionPixelSize(R.styleable.TooltipLayout_ttlm_padding, 30);
             this.mTextAppearance = theme.getResourceId(R.styleable.TooltipLayout_android_textAppearance, 0);
             this.mTextGravity = theme
-                .getInt(R.styleable.TooltipLayout_android_gravity, android.view.Gravity.TOP | android.view.Gravity.START);
+                    .getInt(R.styleable.TooltipLayout_android_gravity, android.view.Gravity.TOP | android.view.Gravity.START);
             this.mTextViewElevation = theme.getDimension(R.styleable.TooltipLayout_ttlm_elevation, 0);
             int overlayStyle = theme.getResourceId(R.styleable.TooltipLayout_ttlm_overlayStyle, R.style.ToolTipOverlayDefaultStyle);
 
@@ -543,39 +543,39 @@ public final class Tooltip {
                 mShowAnimation = ObjectAnimator.ofFloat(this, "alpha", alpha, 0);
                 mShowAnimation.setDuration(fadeDuration);
                 mShowAnimation.addListener(
-                    new Animator.AnimatorListener() {
-                        boolean cancelled;
+                        new Animator.AnimatorListener() {
+                            boolean cancelled;
 
-                        @Override
-                        public void onAnimationStart(final Animator animation) {
-                            cancelled = false;
-                        }
-
-                        @Override
-                        public void onAnimationEnd(final Animator animation) {
-                            if (cancelled) {
-                                return;
+                            @Override
+                            public void onAnimationStart(final Animator animation) {
+                                cancelled = false;
                             }
 
-                            // hide completed
-                            if (null != mCallback) {
-                                mCallback.onTooltipHidden(TooltipViewImpl.this);
+                            @Override
+                            public void onAnimationEnd(final Animator animation) {
+                                if (cancelled) {
+                                    return;
+                                }
+
+                                // hide completed
+                                if (null != mCallback) {
+                                    mCallback.onTooltipHidden(TooltipViewImpl.this);
+                                }
+
+                                remove();
+                                mShowAnimation = null;
                             }
 
-                            remove();
-                            mShowAnimation = null;
-                        }
+                            @Override
+                            public void onAnimationCancel(final Animator animation) {
+                                cancelled = true;
+                            }
 
-                        @Override
-                        public void onAnimationCancel(final Animator animation) {
-                            cancelled = true;
-                        }
+                            @Override
+                            public void onAnimationRepeat(final Animator animation) {
 
-                        @Override
-                        public void onAnimationRepeat(final Animator animation) {
-
+                            }
                         }
-                    }
                 );
                 mShowAnimation.start();
             } else {
@@ -664,7 +664,7 @@ public final class Tooltip {
             return mAttached;
         }
 
-        @SuppressWarnings ("unused")
+        @SuppressWarnings("unused")
         public boolean isShowing() {
             return mShowing;
         }
@@ -712,10 +712,10 @@ public final class Tooltip {
 
             if (null != mViewOverlay) {
                 mViewOverlay.layout(
-                    mViewOverlay.getLeft(),
-                    mViewOverlay.getTop(),
-                    mViewOverlay.getMeasuredWidth(),
-                    mViewOverlay.getMeasuredHeight()
+                        mViewOverlay.getLeft(),
+                        mViewOverlay.getTop(),
+                        mViewOverlay.getMeasuredWidth(),
+                        mViewOverlay.getMeasuredHeight()
                 );
             }
 
@@ -756,7 +756,7 @@ public final class Tooltip {
             removeOnAttachStateObserver(view);
         }
 
-        @SuppressWarnings ("deprecation")
+        @SuppressWarnings("deprecation")
         private void removeGlobalLayoutObserver(@Nullable View view) {
             if (null == view && null != mViewAnchor) {
                 view = mViewAnchor.get();
@@ -794,7 +794,7 @@ public final class Tooltip {
             }
         }
 
-        @SuppressWarnings ("deprecation")
+        @SuppressWarnings("deprecation")
         private void initializeView() {
             if (!isAttached() || mInitialized) {
                 return;
@@ -852,7 +852,7 @@ public final class Tooltip {
             fadeIn(mFadeDuration);
         }
 
-        @SuppressLint ("NewApi")
+        @SuppressLint("NewApi")
         private void setupElevation() {
             mTextView.setElevation(mTextViewElevation);
             mTextView.setOutlineProvider(ViewOutlineProvider.BACKGROUND);
@@ -878,37 +878,37 @@ public final class Tooltip {
                     mShowAnimation.setStartDelay(this.mShowDelay);
                 }
                 mShowAnimation.addListener(
-                    new Animator.AnimatorListener() {
-                        boolean cancelled;
+                        new Animator.AnimatorListener() {
+                            boolean cancelled;
 
-                        @Override
-                        public void onAnimationStart(final Animator animation) {
-                            setVisibility(View.VISIBLE);
-                            cancelled = false;
-                        }
+                            @Override
+                            public void onAnimationStart(final Animator animation) {
+                                setVisibility(View.VISIBLE);
+                                cancelled = false;
+                            }
 
-                        @Override
-                        public void onAnimationEnd(final Animator animation) {
+                            @Override
+                            public void onAnimationEnd(final Animator animation) {
 
-                            if (!cancelled) {
-                                if (null != mCallback) {
-                                    mCallback.onTooltipShown(TooltipViewImpl.this);
+                                if (!cancelled) {
+                                    if (null != mCallback) {
+                                        mCallback.onTooltipShown(TooltipViewImpl.this);
+                                    }
+
+                                    postActivate(mActivateDelay);
                                 }
+                            }
 
-                                postActivate(mActivateDelay);
+                            @Override
+                            public void onAnimationCancel(final Animator animation) {
+                                cancelled = true;
+                            }
+
+                            @Override
+                            public void onAnimationRepeat(final Animator animation) {
+
                             }
                         }
-
-                        @Override
-                        public void onAnimationCancel(final Animator animation) {
-                            cancelled = true;
-                        }
-
-                        @Override
-                        public void onAnimationRepeat(final Animator animation) {
-
-                        }
-                    }
                 );
                 mShowAnimation.start();
             } else {
@@ -948,7 +948,7 @@ public final class Tooltip {
             calculatePositions(viewGravities, restrict);
         }
 
-        @SuppressWarnings ("checkstyle:cyclomaticcomplexity")
+        @SuppressWarnings("checkstyle:cyclomaticcomplexity")
         private void calculatePositions(List<Gravity> gravities, final boolean checkEdges) {
             if (!isAttached()) {
                 return;
@@ -969,8 +969,8 @@ public final class Tooltip {
 
             if (dbg) {
                 log(TAG, DEBUG,
-                    "[%s] calculatePositions. gravity: %s, GRAVITY_LIST: %d, restrict: %b", mToolTipId, gravity,
-                    gravities.size(), checkEdges
+                        "[%s] calculatePositions. gravity: %s, GRAVITY_LIST: %d, restrict: %b", mToolTipId, gravity,
+                        gravities.size(), checkEdges
                 );
             }
 
@@ -1030,7 +1030,7 @@ public final class Tooltip {
 
             if (dbg) {
                 log(TAG, VERBOSE, "[%d] mScreenRect: %s, mTopRule: %d, statusBar: %d", mToolTipId, mScreenRect, mTopRule,
-                    statusbarHeight
+                        statusbarHeight
                 );
                 log(TAG, VERBOSE, "[%d] mDrawRect: %s", mToolTipId, mDrawRect);
                 log(TAG, VERBOSE, "[%d] mViewRect: %s", mToolTipId, mViewRect);
@@ -1069,10 +1069,10 @@ public final class Tooltip {
 
         private void calculatePositionCenter(final boolean checkEdges, final int screenTop, final int width, final int height) {
             mDrawRect.set(
-                mViewRect.centerX() - width / 2,
-                mViewRect.centerY() - height / 2,
-                mViewRect.centerX() + width / 2,
-                mViewRect.centerY() + height / 2
+                    mViewRect.centerX() - width / 2,
+                    mViewRect.centerY() - height / 2,
+                    mViewRect.centerX() + width / 2,
+                    mViewRect.centerY() + height / 2
             );
 
             if (checkEdges && !Utils.rectContainsRectWithTolerance(mScreenRect, mDrawRect, mSizeTolerance)) {
@@ -1090,13 +1090,13 @@ public final class Tooltip {
         }
 
         private boolean calculatePositionLeft(
-            final boolean checkEdges, final int overlayWidth, final int screenTop,
-            final int width, final int height) {
+                final boolean checkEdges, final int overlayWidth, final int screenTop,
+                final int width, final int height) {
             mDrawRect.set(
-                mViewRect.left - width,
-                mViewRect.centerY() - height / 2,
-                mViewRect.left,
-                mViewRect.centerY() + height / 2
+                    mViewRect.left - width,
+                    mViewRect.centerY() - height / 2,
+                    mViewRect.left,
+                    mViewRect.centerY() + height / 2
             );
 
             if ((mViewRect.width() / 2) < overlayWidth) {
@@ -1120,13 +1120,13 @@ public final class Tooltip {
         }
 
         private boolean calculatePositionRight(
-            final boolean checkEdges, final int overlayWidth, final int screenTop,
-            final int width, final int height) {
+                final boolean checkEdges, final int overlayWidth, final int screenTop,
+                final int width, final int height) {
             mDrawRect.set(
-                mViewRect.right,
-                mViewRect.centerY() - height / 2,
-                mViewRect.right + width,
-                mViewRect.centerY() + height / 2
+                    mViewRect.right,
+                    mViewRect.centerY() - height / 2,
+                    mViewRect.right + width,
+                    mViewRect.centerY() + height / 2
             );
 
             if ((mViewRect.width() / 2) < overlayWidth) {
@@ -1150,13 +1150,13 @@ public final class Tooltip {
         }
 
         private boolean calculatePositionTop(
-            final boolean checkEdges, final int overlayHeight, final int screenTop,
-            final int width, final int height) {
+                final boolean checkEdges, final int overlayHeight, final int screenTop,
+                final int width, final int height) {
             mDrawRect.set(
-                mViewRect.centerX() - width / 2,
-                mViewRect.top - height,
-                mViewRect.centerX() + width / 2,
-                mViewRect.top
+                    mViewRect.centerX() - width / 2,
+                    mViewRect.top - height,
+                    mViewRect.centerX() + width / 2,
+                    mViewRect.top
             );
 
             if ((mViewRect.height() / 2) < overlayHeight) {
@@ -1180,13 +1180,13 @@ public final class Tooltip {
         }
 
         private boolean calculatePositionBottom(
-            final boolean checkEdges, final int overlayHeight, final int screenTop,
-            final int width, final int height) {
+                final boolean checkEdges, final int overlayHeight, final int screenTop,
+                final int width, final int height) {
             mDrawRect.set(
-                mViewRect.centerX() - width / 2,
-                mViewRect.bottom,
-                mViewRect.centerX() + width / 2,
-                mViewRect.bottom + height
+                    mViewRect.centerX() - width / 2,
+                    mViewRect.bottom,
+                    mViewRect.centerX() + width / 2,
+                    mViewRect.bottom + height
             );
 
             if (mViewRect.height() / 2 < overlayHeight) {
@@ -1289,7 +1289,7 @@ public final class Tooltip {
             }
         }
 
-        @SuppressWarnings ("checkstyle:cyclomaticcomplexity")
+        @SuppressWarnings("checkstyle:cyclomaticcomplexity")
         @Override
         public boolean onTouchEvent(@NonNull final MotionEvent event) {
             if (!mAttached || !mShowing || !isShown() || mClosePolicy == ClosePolicy.NONE) {
@@ -1325,9 +1325,9 @@ public final class Tooltip {
                     log(TAG, VERBOSE, "[%d] containsTouch: %b", mToolTipId, containsTouch);
                     log(TAG, VERBOSE, "[%d] mDrawRect: %s, point: %g, %g", mToolTipId, mDrawRect, event.getX(), event.getY());
                     log(
-                        TAG,
-                        VERBOSE, "[%d] real drawing rect: %s, contains: %b", mToolTipId, outRect,
-                        outRect.contains((int) event.getX(), (int) event.getY())
+                            TAG,
+                            VERBOSE, "[%d] real drawing rect: %s, contains: %b", mToolTipId, outRect,
+                            outRect.contains((int) event.getX(), (int) event.getY())
                     );
                 }
 
@@ -1414,10 +1414,10 @@ public final class Tooltip {
 
         private void onClose(boolean fromUser, boolean containsTouch, boolean immediate) {
             log(TAG, INFO, "[%d] onClose. fromUser: %b, containsTouch: %b, immediate: %b",
-                mToolTipId,
-                fromUser,
-                containsTouch,
-                immediate
+                    mToolTipId,
+                    fromUser,
+                    containsTouch,
+                    immediate
             );
 
             if (!isAttached()) {
@@ -1438,9 +1438,9 @@ public final class Tooltip {
         int direction;
         long duration;
         boolean completed;
-        @SuppressWarnings ("unused")
+        @SuppressWarnings("unused")
         public static final AnimationBuilder DEFAULT = new AnimationBuilder().build();
-        @SuppressWarnings ("unused")
+        @SuppressWarnings("unused")
         public static final AnimationBuilder SLOW = new AnimationBuilder().setDuration(600).setRadius(4).build();
 
         public AnimationBuilder() {
@@ -1464,7 +1464,7 @@ public final class Tooltip {
         /**
          * @param value 0 for auto, 1 horizontal, 2 vertical
          */
-        @SuppressWarnings ("unused")
+        @SuppressWarnings("unused")
         public AnimationBuilder setDirection(int value) {
             throwIfCompleted();
             this.direction = value;
@@ -1514,12 +1514,12 @@ public final class Tooltip {
             this.id = id;
         }
 
-        @SuppressWarnings ("unused")
+        @SuppressWarnings("unused")
         public Builder() {
             this.id = sNextId++;
         }
 
-        @SuppressWarnings ("unused")
+        @SuppressWarnings("unused")
         public Builder withCustomView(int resId) {
             throwIfCompleted();
             return withCustomView(resId, true);
@@ -1546,7 +1546,7 @@ public final class Tooltip {
             return this;
         }
 
-        @SuppressWarnings ("unused")
+        @SuppressWarnings("unused")
         public Builder withStyleId(int styleId) {
             throwIfCompleted();
             this.defStyleAttr = 0;
@@ -1582,14 +1582,14 @@ public final class Tooltip {
             return this;
         }
 
-        @SuppressWarnings ("unused")
+        @SuppressWarnings("unused")
         public Builder typeface(Typeface typeface) {
             throwIfCompleted();
             this.typeface = typeface;
             return this;
         }
 
-        @SuppressWarnings ("unused")
+        @SuppressWarnings("unused")
         public Builder maxWidth(Resources res, @DimenRes int dimension) {
             return maxWidth(res.getDimensionPixelSize(dimension));
         }
@@ -1625,7 +1625,7 @@ public final class Tooltip {
             return this;
         }
 
-        @SuppressWarnings ("unused")
+        @SuppressWarnings("unused")
         public Builder anchor(final Point point, final Gravity gravity) {
             throwIfCompleted();
             this.view = null;


### PR DESCRIPTION
Line 287`Activity activity = (Activity) getContext();` throwed `ClassCastException` as ContextWrapper cannot be cast to Activity. 
This pull request fixes the problem scanning for the activity or returning null.

The second commit of the pull request just refactors some code to comply with code style required by jitpack.