### PR TITLE
fixed broken link in readme to static inner builder class

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Screenshots
 ![Screen shot](screenshots/image01.png)
 
 
-[1]: https://github.com/sephiroth74/android-target-tooltip/blob/feature/remove_manager/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java#L1191
+[1]: https://github.com/sephiroth74/android-target-tooltip/blob/master/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java#L1471


### PR DESCRIPTION
perhaps the best solution would be to extract the static inner Builder class into it's own class, so the line number will never have to be updated.