### PR TITLE
Check mText is String before casting.

### DIFF
--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
@@ -793,7 +793,11 @@ public final class Tooltip {
             mView.setLayoutParams(params);
 
             mTextView = (TextView) mView.findViewById(android.R.id.text1);
-            mTextView.setText(Html.fromHtml((String) this.mText));
+            if (mText instanceof String) {
+                mTextView.setText(Html.fromHtml((String) mText));
+            } else {
+                mTextView.setText(mText);
+            }
             if (mMaxWidth > -1) {
                 mTextView.setMaxWidth(mMaxWidth);
                 log(TAG, VERBOSE, "[%d] maxWidth: %d", mToolTipId, mMaxWidth);


### PR DESCRIPTION
Fixes ClassCastException in the event a non-String CharSequence
instance such as a SpannableString is used.