### PR TITLE
Fix frameLayoutlayoutChildren crash

### DIFF
--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
@@ -571,11 +571,17 @@ public final class Tooltip {
 
         void removeFromParent() {
             log(TAG, INFO, "[%d] removeFromParent", mToolTipId);
-            ViewParent parent = getParent();
+            final ViewParent parent = getParent();
             removeCallbacks();
 
             if (null != parent) {
-                ((ViewGroup) parent).removeView(TooltipViewImpl.this);
+                ((ViewGroup) parent).post(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        ((ViewGroup) parent).removeView(TooltipViewImpl.this);
+                    }
+                });
 
                 if (null != mShowAnimation && mShowAnimation.isStarted()) {
                     mShowAnimation.cancel();


### PR DESCRIPTION
When use this lib in RecyclerView or ListView etc..., sometimes will crash at FrameLayout.
If you test this crash by yourself maybe you should test 1,000 times or more.

In my app, this crash is a fatal issue.
![4](https://cloud.githubusercontent.com/assets/5742579/21599967/2602bbde-d1b0-11e6-99b7-165fb5b737d4.png)

You can see the crash like this:
```
Fatal Exception: java.lang.NullPointerException
       at android.widget.FrameLayout.layoutChildren(FrameLayout.java:405)
       at android.widget.FrameLayout.onLayout(FrameLayout.java:388)
       at android.view.View.layout(View.java:15749)
       at android.view.ViewGroup.layout(ViewGroup.java:4880)
       at android.support.v4.widget.SwipeRefreshLayout.onLayout(SwipeRefreshLayout.java:596)
       at android.view.View.layout(View.java:15749)
       at android.view.ViewGroup.layout(ViewGroup.java:4880)
```
It crash place depends on your Android os.

I try to find this crash for three months.
Finally, I fixed it.

Cheers,
HearSilent