### PR TITLE
Added canScroll and onClickListener options to Tooltip.Builder, and upgraded gradle build tools

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,17 +2,12 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion ANDROID_BUILD_SDK_VERSION as int
-    buildToolsVersion ANDROID_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion ANDROID_BUILD_TARGET_SDK_VERSION as int
         versionCode 1
         versionName VERSION_NAME
-
-        jackOptions {
-            enabled false
-        }
     }
     buildTypes {
         release {
@@ -22,8 +17,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     lintOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.0.1'
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 24 16:36:36 EST 2017
+#Thu Jan 11 12:22:21 PST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,7 +5,6 @@ version VERSION_NAME
 
 android {
     compileSdkVersion ANDROID_BUILD_SDK_VERSION as int
-    buildToolsVersion ANDROID_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 14
@@ -24,8 +23,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     lintOptions {

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
@@ -22,6 +22,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.text.Html;
 import android.text.TextUtils;
+import android.text.method.ScrollingMovementMethod;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -208,6 +209,8 @@ public final class Tooltip {
         void setTextColor(final ColorStateList color);
 
         void requestLayout();
+
+        TextView getTextView();
     }
 
     public interface Callback {
@@ -259,6 +262,7 @@ public final class Tooltip {
         private final Point mTmpPoint = new Point();
         private final Rect mHitRect = new Rect();
         private final float mTextViewElevation;
+        private final boolean mCanScroll;
         private Callback mCallback;
         private int[] mOldLocation;
         private Gravity mGravity;
@@ -394,6 +398,7 @@ public final class Tooltip {
             };
 
         private boolean mIsCustomView;
+        private OnClickListener mOnClickListener;
 
         public TooltipViewImpl(Context context, final Builder builder) {
             super(context);
@@ -428,6 +433,8 @@ public final class Tooltip {
             this.mCallback = builder.closeCallback;
             this.mFloatingAnimation = builder.floatingAnimation;
             this.mSizeTolerance = (int) (context.getResources().getDisplayMetrics().density * TOLERANCE_VALUE);
+            this.mCanScroll = builder.canScroll;
+            this.mOnClickListener = builder.onClickListener;
 
             if (builder.typeface != null) {
                 mTypeface = builder.typeface;
@@ -642,6 +649,11 @@ public final class Tooltip {
         }
 
         @Override
+        public TextView getTextView() {
+            return mTextView;
+        }
+
+        @Override
         public boolean isAttached() {
             return mAttached;
         }
@@ -822,6 +834,14 @@ public final class Tooltip {
 
             if (!mIsCustomView && mTextViewElevation > 0 && Build.VERSION.SDK_INT >= 21) {
                 setupElevation();
+            }
+
+            if (mCanScroll) {
+                mTextView.setMovementMethod(ScrollingMovementMethod.getInstance());
+            }
+
+            if (mOnClickListener != null) {
+                mTextView.setOnClickListener(mOnClickListener);
             }
         }
 
@@ -1477,6 +1497,8 @@ public final class Tooltip {
         boolean overlay = true;
         AnimationBuilder floatingAnimation;
         Typeface typeface;
+        boolean canScroll;
+        View.OnClickListener onClickListener;
 
         public Builder(int id) {
             this.id = id;
@@ -1648,6 +1670,16 @@ public final class Tooltip {
         public Builder showDelay(long ms) {
             throwIfCompleted();
             this.showDelay = ms;
+            return this;
+        }
+
+        public Builder canScroll(boolean enabled) {
+            this.canScroll = enabled;
+            return this;
+        }
+
+        public Builder onClickListener(View.OnClickListener onClickListener) {
+            this.onClickListener = onClickListener;
             return this;
         }
 

--- a/library/src/main/res/layout/tooltip_textview.xml
+++ b/library/src/main/res/layout/tooltip_textview.xml
@@ -11,5 +11,6 @@
         android:layout_height="wrap_content"
         android:autoLink="all"
         android:clipToPadding="false"
+        android:scrollbars="vertical"
         android:textAppearance="?android:attr/textAppearanceSmallInverse" />
 </FrameLayout>


### PR DESCRIPTION
This update adds two new options to the Tooltip Builder: `canScroll` and `onClickListener`.   Getting the TextView object is also exposed as an interface method, so further customizations can be done after the tooltip is shown especially when clients provide a custom TextView via `builder.withCustomView()`. The gradle files have also been updated to 3.0.1 and compile with Java 8