### PR TITLE
AndroidX conversion + Dialog support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ jdk:
 android:
   components:
     - tools
-    - build-tools-25.0.2
-    - android-25
+    - build-tools-28.0.3
+    - android-28
     - extra-android-m2repository
     - extra-google-m2repository
     - extra-android-support

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,17 +2,12 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion ANDROID_BUILD_SDK_VERSION as int
-    buildToolsVersion ANDROID_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion ANDROID_BUILD_TARGET_SDK_VERSION as int
         versionCode 1
         versionName VERSION_NAME
-
-        jackOptions {
-            enabled false
-        }
     }
     buildTypes {
         release {
@@ -38,12 +33,13 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(':library')
-    compile 'com.android.support:appcompat-v7:24.1.1'
-    compile 'com.android.support:design:24.1.1'
-    compile 'com.android.support:recyclerview-v7:24.1.1'
+    implementation project(':library')
 
-    debugCompile 'com.squareup.leakcanary:leakcanary-android:1.3.1'
-    releaseCompile 'com.squareup.leakcanary:leakcanary-android-no-op:1.3.1'
+    implementation "androidx.appcompat:appcompat:1.0.0"
+    implementation "androidx.recyclerview:recyclerview:1.0.0"
+    implementation "androidx.viewpager:viewpager:1.0.0"
+    implementation "com.google.android.material:material:1.0.0"
+
+    debugImplementation 'com.squareup.leakcanary:leakcanary-android:1.6.2'
+    releaseImplementation 'com.squareup.leakcanary:leakcanary-android-no-op:1.6.2'
 }

--- a/app/src/main/java/it/sephiroth/android/library/mymodule/app/MainActivity2.java
+++ b/app/src/main/java/it/sephiroth/android/library/mymodule/app/MainActivity2.java
@@ -2,16 +2,10 @@ package it.sephiroth.android.library.mymodule.app;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.design.widget.TabLayout;
-import android.support.v4.app.Fragment;
-import android.support.v4.app.FragmentManager;
-import android.support.v4.app.FragmentPagerAdapter;
-import android.support.v4.view.ViewPager;
-import android.support.v4.view.ViewPager.OnPageChangeListener;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.SwitchCompat;
-import android.support.v7.widget.Toolbar;
+import androidx.annotation.Nullable;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -21,14 +15,21 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CompoundButton;
+import android.widget.Switch;
+
+import com.google.android.material.tabs.TabLayout;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentManager;
+import androidx.fragment.app.FragmentPagerAdapter;
+import androidx.viewpager.widget.ViewPager;
 import it.sephiroth.android.library.tooltip.Tooltip;
 import it.sephiroth.android.library.tooltip.Tooltip.AnimationBuilder;
 
-public class MainActivity2 extends AppCompatActivity implements OnPageChangeListener {
+public class MainActivity2 extends AppCompatActivity implements ViewPager.OnPageChangeListener {
     private static final String TAG = MainActivity2.class.getSimpleName();
     ViewPager mViewPager;
 
@@ -38,7 +39,7 @@ public class MainActivity2 extends AppCompatActivity implements OnPageChangeList
         setContentView(R.layout.activity_main_activity2);
         setSupportActionBar((Toolbar) findViewById(R.id.toolbar));
 
-        mViewPager = (ViewPager) findViewById(R.id.viewpager);
+        mViewPager = findViewById(R.id.viewpager);
         mViewPager.addOnPageChangeListener(this);
         setupViewPager(mViewPager);
         Tooltip.dbg = true;
@@ -172,10 +173,10 @@ public class MainActivity2 extends AppCompatActivity implements OnPageChangeList
         Button mButton3;
         Button mButton4;
         Button mButton5;
-        SwitchCompat mSwitch1;
-        SwitchCompat mSwitch2;
-        SwitchCompat mSwitch3;
-        SwitchCompat mSwitch4;
+        Switch mSwitch1;
+        Switch mSwitch2;
+        Switch mSwitch3;
+        Switch mSwitch4;
         private Tooltip.TooltipView tooltip;
         private Tooltip.ClosePolicy mClosePolicy = Tooltip.ClosePolicy.TOUCH_ANYWHERE_CONSUME;
 
@@ -190,21 +191,21 @@ public class MainActivity2 extends AppCompatActivity implements OnPageChangeList
         public void onViewCreated(final View view, @Nullable final Bundle savedInstanceState) {
             super.onViewCreated(view, savedInstanceState);
 
-            mButton1 = (Button) view.findViewById(R.id.button1);
-            mButton2 = (Button) view.findViewById(R.id.button2);
-            mButton3 = (Button) view.findViewById(R.id.button3);
-            mButton4 = (Button) view.findViewById(R.id.button4);
-            mButton5 = (Button) view.findViewById(R.id.button5);
+            mButton1 = view.findViewById(R.id.button1);
+            mButton2 = view.findViewById(R.id.button2);
+            mButton3 = view.findViewById(R.id.button3);
+            mButton4 = view.findViewById(R.id.button4);
+            mButton5 = view.findViewById(R.id.button5);
             mButton1.setOnClickListener(this);
             mButton2.setOnClickListener(this);
             mButton3.setOnClickListener(this);
             mButton4.setOnClickListener(this);
             mButton5.setOnClickListener(this);
 
-            mSwitch1 = (SwitchCompat) view.findViewById(R.id.switch1);
-            mSwitch2 = (SwitchCompat) view.findViewById(R.id.switch2);
-            mSwitch3 = (SwitchCompat) view.findViewById(R.id.switch3);
-            mSwitch4 = (SwitchCompat) view.findViewById(R.id.switch4);
+            mSwitch1 = view.findViewById(R.id.switch1);
+            mSwitch2 = view.findViewById(R.id.switch2);
+            mSwitch3 = view.findViewById(R.id.switch3);
+            mSwitch4 = view.findViewById(R.id.switch4);
 
             final int policy = mClosePolicy.getPolicy();
             mSwitch1.setChecked(Tooltip.ClosePolicy.touchInside(policy));

--- a/app/src/main/java/it/sephiroth/android/library/mymodule/app/MainActivity3.java
+++ b/app/src/main/java/it/sephiroth/android/library/mymodule/app/MainActivity3.java
@@ -3,10 +3,6 @@ package it.sephiroth.android.library.mymodule.app;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.Toolbar;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -20,6 +16,10 @@ import android.widget.TextView;
 import java.util.ArrayList;
 import java.util.List;
 
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 import it.sephiroth.android.library.tooltip.Tooltip;
 
 public class MainActivity3 extends AppCompatActivity implements AdapterView.OnItemClickListener {
@@ -44,8 +44,8 @@ public class MainActivity3 extends AppCompatActivity implements AdapterView.OnIt
 
         displayMetrics = getResources().getDisplayMetrics();
 
-        mRecyclerView = (RecyclerView) findViewById(R.id.recyclerView);
-        mRecyclerView.setLayoutManager(new LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false));
+        mRecyclerView = findViewById(R.id.recyclerView);
+        mRecyclerView.setLayoutManager(new LinearLayoutManager(this, RecyclerView.VERTICAL, false));
         mRecyclerView.setAdapter(new MyAdapter(this, R.layout.custom_list_textview, array));
         mRecyclerView.setHasFixedSize(true);
         mRecyclerView.addOnScrollListener(

--- a/app/src/main/res/layout/activity2_fragment1.xml
+++ b/app/src/main/res/layout/activity2_fragment1.xml
@@ -13,7 +13,7 @@
     android:weightSum="2"
     tools:context="it.sephiroth.android.library.mymodule.app.MainActivity2">
 
-    <android.support.v7.widget.AppCompatTextView
+    <TextView
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_gravity="top"
@@ -29,7 +29,7 @@
         android:columnCount="2"
         android:rowCount="3">
 
-        <android.support.v7.widget.AppCompatTextView
+        <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_column="0"
@@ -39,7 +39,7 @@
             android:gravity="center"
             android:text="Change the tooltip close policy" />
 
-        <android.support.v7.widget.SwitchCompat
+        <Switch
             android:id="@+id/switch1"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -48,7 +48,7 @@
             android:layout_row="1"
             android:text="Touch Inside" />
 
-        <android.support.v7.widget.SwitchCompat
+        <Switch
             android:id="@+id/switch2"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -57,7 +57,7 @@
             android:layout_row="2"
             android:text="Consume Inside" />
 
-        <android.support.v7.widget.SwitchCompat
+        <Switch
             android:id="@+id/switch3"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -66,7 +66,7 @@
             android:layout_row="1"
             android:text="Touch Outside" />
 
-        <android.support.v7.widget.SwitchCompat
+        <Switch
             android:id="@+id/switch4"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/activity_main_activity2.xml
+++ b/app/src/main/res/layout/activity_main_activity2.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/activity_main_app_bar"
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
@@ -16,14 +16,14 @@
         tools:ignore="UnusedAttribute">
 
         <!-- The toolbar -->
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:background="?attr/colorPrimaryDark"
             android:layout_height="?attr/actionBarSize"
             android:minHeight="?attr/actionBarSize" />
 
-        <android.support.design.widget.TabLayout
+        <com.google.android.material.tabs.TabLayout
             android:id="@+id/tabs"
             app:tabBackground="?attr/colorPrimaryDark"
             android:background="?attr/colorPrimaryDark"
@@ -33,11 +33,11 @@
             android:layout_height="wrap_content"
             app:tabMode="fixed" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
 
     <!-- grid fragment container -->
-    <android.support.v4.view.ViewPager
+    <androidx.viewpager.widget.ViewPager
         android:id="@+id/viewpager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/activity_main_activity3.xml
+++ b/app/src/main/res/layout/activity_main_activity3.xml
@@ -5,7 +5,7 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <android.support.design.widget.AppBarLayout
+    <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/activity_main_app_bar"
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
@@ -15,13 +15,13 @@
         tools:ignore="UnusedAttribute">
 
         <!-- The toolbar -->
-        <android.support.v7.widget.Toolbar
+        <androidx.appcompat.widget.Toolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
             android:layout_height="?attr/actionBarSize"
             android:minHeight="?attr/actionBarSize" />
 
-    </android.support.design.widget.AppBarLayout>
+    </com.google.android.material.appbar.AppBarLayout>
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
@@ -34,12 +34,12 @@
         android:paddingRight="@dimen/activity_horizontal_margin"
         android:paddingTop="@dimen/activity_vertical_margin">
 
-        <android.support.v7.widget.RecyclerView
+        <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/recyclerView"
             android:layout_width="match_parent"
             android:layout_height="match_parent">
 
-        </android.support.v7.widget.RecyclerView>
+        </androidx.recyclerview.widget.RecyclerView>
 
     </LinearLayout>
 </LinearLayout>

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,11 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta2'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
@@ -16,6 +17,7 @@ allprojects {
     repositories {
         jcenter()
         mavenCentral()
+        google()
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,8 +16,10 @@ POM_DEVELOPER_EMAIL=alessandro.crugnola@gmail.com
 POM_DEVELOPER_URL=http://blog.sephiroth.it
 POM_DEVELOPER_ROLE=author
 
-ANDROID_BUILD_TARGET_SDK_VERSION=25
-ANDROID_BUILD_TOOLS_VERSION=25.0.2
-ANDROID_BUILD_SDK_VERSION=25
+ANDROID_BUILD_TARGET_SDK_VERSION=28
+ANDROID_BUILD_SDK_VERSION=28
 
 org.gradle.daemon=true
+
+android.useAndroidX=true
+android.enableJetifier=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,8 +4,8 @@ group GROUP
 version VERSION_NAME
 
 android {
-    compileSdkVersion ANDROID_BUILD_SDK_VERSION as int
-    buildToolsVersion ANDROID_BUILD_TOOLS_VERSION
+    compileSdkVersion ANDROID_BUILD_SDK_VERSION as int // must be 28!
+    //buildToolsVersion ANDROID_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 14
@@ -43,8 +43,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    provided 'com.android.support:support-annotations:24.1.1'
-    compile 'com.android.support:appcompat-v7:24.1.1'
+    implementation "androidx.appcompat:appcompat:1.0.0"
 }
 
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -4,14 +4,11 @@ group GROUP
 version VERSION_NAME
 
 android {
-    compileSdkVersion ANDROID_BUILD_SDK_VERSION as int // must be 28!
-    //buildToolsVersion ANDROID_BUILD_TOOLS_VERSION
+    compileSdkVersion ANDROID_BUILD_SDK_VERSION as int
 
     defaultConfig {
         minSdkVersion 14
         targetSdkVersion ANDROID_BUILD_TARGET_SDK_VERSION as int
-        versionCode 1
-        versionName VERSION_NAME
         consumerProguardFiles 'proguard-rules.txt'
     }
 
@@ -42,7 +39,6 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.appcompat:appcompat:1.0.0"
 }
 

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
@@ -1031,7 +1031,6 @@ public final class Tooltip {
 
             // correction needed -> popups root view does NOT contain status bar!
             if (mShowAsPopup) {
-//                screenTop = Utils.getStatusBarHeight(getContext());
                 int realStatusBarHeight = Utils.getStatusBarHeight(getContext());
                 mViewRect.top -= realStatusBarHeight;
                 mViewRect.bottom -= realStatusBarHeight;

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
@@ -497,6 +497,17 @@ public final class Tooltip {
                         mPopup = new PopupWindow(this, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT,true);
                         // view serves as window token provider only here!
                         mPopup.showAtLocation(v, android.view.Gravity.BOTTOM, 0, 0);
+                        v.addOnAttachStateChangeListener(new OnAttachStateChangeListener() {
+                            @Override
+                            public void onViewAttachedToWindow(View view) {
+
+                            }
+
+                            @Override
+                            public void onViewDetachedFromWindow(View view) {
+                                removePopup();
+                            }
+                        });
                     }
                 }
             } else if (getParent() == null) {
@@ -685,6 +696,12 @@ public final class Tooltip {
         }
 
         @Override
+        protected void onConfigurationChanged(Configuration newConfig) {
+            removePopup();
+            super.onConfigurationChanged(newConfig);
+        }
+
+        @Override
         protected void onDetachedFromWindow() {
             log(TAG, INFO, "[%d] onDetachedFromWindow", mToolTipId);
             removePopup();
@@ -739,7 +756,8 @@ public final class Tooltip {
 
         private void removePopup() {
             if (mPopup != null) {
-                mPopup.dismiss();
+                if (mPopup.isShowing())
+                    mPopup.dismiss();
                 mPopup = null;
             }
         }

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
@@ -16,6 +16,7 @@ import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.os.Build;
 import android.os.Handler;
+import android.os.IBinder;
 import android.text.Html;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
@@ -25,6 +26,7 @@ import android.view.ViewGroup;
 import android.view.ViewOutlineProvider;
 import android.view.ViewParent;
 import android.view.ViewTreeObserver;
+import android.view.WindowInsets;
 import android.view.WindowManager;
 import android.view.animation.AccelerateDecelerateInterpolator;
 import android.widget.PopupWindow;
@@ -685,6 +687,7 @@ public final class Tooltip {
         @Override
         protected void onDetachedFromWindow() {
             log(TAG, INFO, "[%d] onDetachedFromWindow", mToolTipId);
+            removePopup();
             removeListeners();
             stopFloatingAnimations();
             mAttached = false;
@@ -731,6 +734,13 @@ public final class Tooltip {
                     }
                 }
                 calculatePositions();
+            }
+        }
+
+        private void removePopup() {
+            if (mPopup != null) {
+                mPopup.dismiss();
+                mPopup = null;
             }
         }
 
@@ -1029,11 +1039,20 @@ public final class Tooltip {
                 calculatePositionCenter(checkEdges, screenTop, width, height);
             }
 
-            // correction needed -> popups root view does NOT contain status bar!
+            // correction needed to support dialog as well e.g.
+            // => better solution would be to take this into account in calcualtions,
+            // but for now a post calculation correction must do it
             if (mShowAsPopup) {
                 int realStatusBarHeight = Utils.getStatusBarHeight(getContext());
                 mViewRect.top -= realStatusBarHeight;
                 mViewRect.bottom -= realStatusBarHeight;
+
+                Rect outRect = new Rect();
+                mView.getWindowVisibleDisplayFrame(outRect);
+                mViewRect.left -= outRect.left;
+                mViewRect.top -= outRect.top;
+                mDrawRect.left -= outRect.left;
+                mDrawRect.top -= outRect.top;
             }
 
             if (dbg) {

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
@@ -494,7 +494,8 @@ public final class Tooltip {
                 if (mPopup == null) {
                     View v = mViewAnchor.get();
                     if (v != null) {
-                        mPopup = new PopupWindow(this, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT,true);
+                        mPopup = new PopupWindow(this, LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT,
+                                true);
                         // view serves as window token provider only here!
                         mPopup.showAtLocation(v, android.view.Gravity.BOTTOM, 0, 0);
                         v.addOnAttachStateChangeListener(new OnAttachStateChangeListener() {

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Tooltip.java
@@ -396,7 +396,7 @@ public final class Tooltip {
             };
 
         private boolean mIsCustomView;
-        private boolean mShowAsPopup = false;
+        private boolean mShowAsPopup;
         private PopupWindow mPopup = null;
 
         public TooltipViewImpl(Context context, final Builder builder) {

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipOverlay.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipOverlay.java
@@ -3,9 +3,10 @@ package it.sephiroth.android.library.tooltip;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
-import android.widget.ImageView;
 
-public class TooltipOverlay extends ImageView {
+import androidx.appcompat.widget.AppCompatImageView;
+
+public class TooltipOverlay extends AppCompatImageView {
     private int mMargins;
 
     public TooltipOverlay(Context context) {

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipTextDrawable.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/TooltipTextDrawable.java
@@ -14,7 +14,8 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.support.annotation.Nullable;
+
+import androidx.annotation.Nullable;
 
 class TooltipTextDrawable extends Drawable {
     public static final float ARROW_RATIO_DEFAULT = 1.4f;

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Utils.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Utils.java
@@ -3,8 +3,10 @@ package it.sephiroth.android.library.tooltip;
 import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
+import android.content.res.Configuration;
 import android.graphics.Rect;
 import android.os.Build;
+import android.util.DisplayMetrics;
 import android.util.Log;
 
 import androidx.annotation.NonNull;
@@ -18,7 +20,8 @@ import static it.sephiroth.android.library.tooltip.Tooltip.dbg;
  * Created by alessandro crugnola on 12/12/15.
  */
 final class Utils {
-    private Utils() { }
+    private Utils() {
+    }
 
     @Nullable
     static Activity getActivity(@Nullable Context cont) {
@@ -72,5 +75,34 @@ final class Utils {
             result = (int) Math.ceil((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? 24 : 25) * context.getResources().getDisplayMetrics().density);
         }
         return result;
+    }
+
+    static int getSoftButtonsBarHeight(Context context) {
+        // getRealMetrics is only available with API 17 and +
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            Activity activity = getActivity(context);
+            if (activity == null) {
+                return 0;
+            }
+            int orientation = activity.getResources().getConfiguration().orientation;
+            DisplayMetrics metrics = new DisplayMetrics();
+            activity.getWindowManager().getDefaultDisplay().getMetrics(metrics);
+            int usableSize = orientation == Configuration.ORIENTATION_LANDSCAPE ? metrics.widthPixels : metrics.heightPixels;
+            activity.getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
+            int realSize = orientation == Configuration.ORIENTATION_LANDSCAPE ? metrics.widthPixels : metrics.heightPixels;
+            if (realSize > usableSize)
+                return realSize - usableSize;
+            else
+                return 0;
+        }
+        return 0;
+    }
+
+    static int getDeviceRotation(Context context) {
+        Activity activity = getActivity(context);
+        if (activity == null) {
+            return -1;
+        }
+        return activity.getWindowManager().getDefaultDisplay().getRotation();
     }
 }

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Utils.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Utils.java
@@ -4,9 +4,11 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.graphics.Rect;
-import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
+import android.os.Build;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import static android.util.Log.INFO;
 import static android.util.Log.VERBOSE;
@@ -59,5 +61,16 @@ final class Utils {
 
     static boolean rectContainsRectWithTolerance(@NonNull final Rect parentRect, @NonNull final Rect childRect, final int t) {
         return parentRect.contains(childRect.left + t, childRect.top + t, childRect.right - t, childRect.bottom - t);
+    }
+
+    static int getStatusBarHeight(Context context) {
+        int result = 0;
+        int resourceId = context.getResources().getIdentifier("status_bar_height", "dimen", "android");
+        if (resourceId > 0) {
+            result = context.getResources().getDimensionPixelSize(resourceId);
+        } else {
+            result = (int) Math.ceil((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? 24 : 25) * context.getResources().getDisplayMetrics().density);
+        }
+        return result;
     }
 }

--- a/library/src/main/java/it/sephiroth/android/library/tooltip/Utils.java
+++ b/library/src/main/java/it/sephiroth/android/library/tooltip/Utils.java
@@ -72,7 +72,8 @@ final class Utils {
         if (resourceId > 0) {
             result = context.getResources().getDimensionPixelSize(resourceId);
         } else {
-            result = (int) Math.ceil((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? 24 : 25) * context.getResources().getDisplayMetrics().density);
+            result = (int) Math.ceil((Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? 24 : 25)
+                    * context.getResources().getDisplayMetrics().density);
         }
         return result;
     }
@@ -90,10 +91,11 @@ final class Utils {
             int usableSize = orientation == Configuration.ORIENTATION_LANDSCAPE ? metrics.widthPixels : metrics.heightPixels;
             activity.getWindowManager().getDefaultDisplay().getRealMetrics(metrics);
             int realSize = orientation == Configuration.ORIENTATION_LANDSCAPE ? metrics.widthPixels : metrics.heightPixels;
-            if (realSize > usableSize)
+            if (realSize > usableSize) {
                 return realSize - usableSize;
-            else
+            } else {
                 return 0;
+            }
         }
         return 0;
     }


### PR DESCRIPTION
**Changes**

* converted the project to android x
* made extended views extend app compat views for proper view styling on all versions
* added `asPopup` to the builder => this mode supports dialogs as well now and will simply use an android `PopupWindow`

**Info**

I added support for dialogs not by using the `WindowManager` (which I saw you already tried in the open issues) but by simply using a `PopupWindow` which will retrieve the window token from the view itself and this seems to work fine as long as you adjust the top offset to remove the status bar height...

For dialogs, you must find the correct window position and adjust position accordingly as well, which I implemented as well now.

So far, this looks quite good now, but I do corrections after the calculations instead of before, just because it's easier for me now... This could be improved though...

And there seems to be a very small offset in dialogs - I don't know to fix them yet, but it works at least and is accurate enough...