### PR TITLE
fix: Make custom attributes avialable to user defined styles

### DIFF
--- a/xtooltip/src/main/java/it/sephiroth/android/library/xtooltip/Tooltip.kt
+++ b/xtooltip/src/main/java/it/sephiroth/android/library/xtooltip/Tooltip.kt
@@ -858,12 +858,11 @@ class Tooltip private constructor(private val context: Context, builder: Builder
 
         fun styleId(@StyleRes styleId: Int?): Builder {
             styleId?.let {
-                this.defStyleAttr = 0
                 this.defStyleRes = it
             } ?: run {
                 this.defStyleRes = R.style.ToolTipLayoutDefaultStyle
-                this.defStyleAttr = R.attr.ttlm_defaultStyle
             }
+            this.defStyleAttr = R.attr.ttlm_defaultStyle
             return this
         }
 


### PR DESCRIPTION
This lets the user make use of tooltip attributes even while using custom styles.