### PR TITLE
remove overlay view on dismiss to allow hide and show again

### DIFF
--- a/xtooltip/src/main/java/it/sephiroth/android/library/xtooltip/Tooltip.kt
+++ b/xtooltip/src/main/java/it/sephiroth/android/library/xtooltip/Tooltip.kt
@@ -651,6 +651,7 @@ class Tooltip private constructor(private val context: Context, builder: Builder
             removeCallbacks()
             windowManager.removeView(mPopupView)
             Timber.v("dismiss: $mPopupView")
+            mPopupView?.run{ removeView(mViewOverlay) }
             mPopupView = null
             isShowing = false
             isVisible = false


### PR DESCRIPTION
Currently when dismissing the tooltip the overlay view is not removed from the parent view, when trying to show it again the code tries to add the view to the new parent and fails with this error:
```
2019-06-30 15:31:45.576 19194-19194/it.sephiroth.android.library.tooltip_demo E/AndroidRuntime: FATAL EXCEPTION: main
    Process: it.sephiroth.android.library.tooltip_demo, PID: 19194
    java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
        at android.view.ViewGroup.addViewInner(ViewGroup.java:5034)
        at android.view.ViewGroup.addView(ViewGroup.java:4865)
        at android.view.ViewGroup.addView(ViewGroup.java:4837)
        at it.sephiroth.android.library.xtooltip.Tooltip.preparePopup(Tooltip.kt:337)
        at it.sephiroth.android.library.xtooltip.Tooltip.show(Tooltip.kt:623)
        at it.sephiroth.android.library.tooltip_demo.MainActivity$onCreate$1$4.run(MainActivity.kt:71)
        at android.os.Handler.handleCallback(Handler.java:873)
        at android.os.Handler.dispatchMessage(Handler.java:99)
        at android.os.Looper.loop(Looper.java:193)
        at android.app.ActivityThread.main(ActivityThread.java:6718)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)

```
added code to remove the overlay view from its parent when dismissing (or hiding) the tooltip.

now it is possible to hide and show the same tooltip over and over again.