### PR TITLE
Add on click event listener

### DIFF
--- a/xtooltip/src/main/java/it/sephiroth/android/library/xtooltip/Tooltip.kt
+++ b/xtooltip/src/main/java/it/sephiroth/android/library/xtooltip/Tooltip.kt
@@ -203,6 +203,7 @@ class Tooltip private constructor(private val context: Context, builder: Builder
     private var mPrepareFun: ((tooltip: Tooltip) -> Unit)? = null
     private var mShownFunc: ((tooltip: Tooltip) -> Unit)? = null
     private var mHiddenFunc: ((tooltip: Tooltip) -> Unit)? = null
+    private var mClickFunc: ((tooltip: Tooltip) -> Unit)? = null
 
     @Suppress("UNUSED")
     fun doOnFailure(func: ((tooltip: Tooltip) -> Unit)?): Tooltip {
@@ -225,6 +226,12 @@ class Tooltip private constructor(private val context: Context, builder: Builder
     @Suppress("UNUSED")
     fun doOnHidden(func: ((tooltip: Tooltip) -> Unit)?): Tooltip {
         mHiddenFunc = func
+        return this
+    }
+
+    @Suppress("UNUSED")
+    fun doOnClick(func: ((tooltip: Tooltip) -> Unit)?): Tooltip {
+        mClickFunc = func
         return this
     }
 
@@ -761,12 +768,17 @@ class Tooltip private constructor(private val context: Context, builder: Builder
             mTextView.getGlobalVisibleRect(r1)
             val containsTouch = r1.contains(event.x.toInt(), event.y.toInt())
 
-            if (mClosePolicy.anywhere()) {
-                hide()
-            } else if (mClosePolicy.inside() && containsTouch) {
-                hide()
-            } else if (mClosePolicy.outside() && !containsTouch) {
-                hide()
+            when {
+                mClosePolicy.inside() && containsTouch -> {
+                    hide()
+                    mClickFunc?.invoke(this@Tooltip)
+                }
+                mClosePolicy.outside() && !containsTouch -> {
+                    hide()
+                }
+                mClosePolicy.anywhere() -> {
+                    hide()
+                }
             }
 
             return mClosePolicy.consume()


### PR DESCRIPTION
On my application, I have to show the copy tooltip and execute copy function when clicking it and hide it whenever touching on the screen.
To fix this scenario, I have to add on click event listener.
So I think click event listener should be added with the new function `doOnClick`